### PR TITLE
fix: 🐛 display proper tags in modal

### DIFF
--- a/src/components/DashboardShare/components/EmbedCode/EmbedCode.tsx
+++ b/src/components/DashboardShare/components/EmbedCode/EmbedCode.tsx
@@ -121,7 +121,7 @@ const EmbedCode: FC<Props> = ({ dashboardId, isPublic }) => {
             marginLeft="10px"
             dangerouslySetInnerHTML={{
               __html: t('dashboard_share.embed_step_first', {
-                tag: '<strong>head</strong>',
+                tag: '<strong>&lt;head&gt;</strong>',
                 interpolation: { escapeValue: false },
               }),
             }}
@@ -158,7 +158,7 @@ const EmbedCode: FC<Props> = ({ dashboardId, isPublic }) => {
             marginLeft="10px"
             dangerouslySetInnerHTML={{
               __html: t('dashboard_share.embed_step_second', {
-                tag: '<strong>body</strong>',
+                tag: '<strong>&lt;body&gt;</strong>',
                 interpolation: { escapeValue: false },
               }),
             }}


### PR DESCRIPTION
<img width="600" alt="Screenshot 2021-02-02 at 13 40 24" src="https://user-images.githubusercontent.com/23423731/106602490-61140d00-655d-11eb-8a8d-a50402112f86.png">
