### PR TITLE
fix: 🐛 limit DashboardTile width

### DIFF
--- a/src/components/DashboardsList/DashboardsList.styles.ts
+++ b/src/components/DashboardsList/DashboardsList.styles.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const DashboardsGrid = styled.div`
   display: grid;
   grid-gap: 20px;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(300px, 380px));
 `;
 
 export const DashboardItem = styled.div`


### PR DESCRIPTION
* before
<img width="1440" alt="Screenshot 2021-04-22 at 16 22 13" src="https://user-images.githubusercontent.com/23423731/115731282-4d6f8a00-a387-11eb-82c9-4869a296ceb1.png">
<img width="1440" alt="Screenshot 2021-04-22 at 16 22 20" src="https://user-images.githubusercontent.com/23423731/115731305-51031100-a387-11eb-8eef-8bced745e8ab.png">
* after
<img width="1440" alt="Screenshot 2021-04-22 at 16 21 43" src="https://user-images.githubusercontent.com/23423731/115731363-5e200000-a387-11eb-8de2-8ca4b66fbb79.png">
<img width="1440" alt="Screenshot 2021-04-22 at 16 22 27" src="https://user-images.githubusercontent.com/23423731/115731382-61b38700-a387-11eb-9ad6-7d38bb111e22.png">
