### PR TITLE
Fix/color selector test

### DIFF
--- a/src/components/ThemeEditor/components/ColorSelector/ColorSelector.test.tsx
+++ b/src/components/ThemeEditor/components/ColorSelector/ColorSelector.test.tsx
@@ -18,6 +18,8 @@ const render = (overProps: any = {}) => {
   };
 };
 
+HTMLCanvasElement.prototype.getContext = jest.fn();
+
 test('should render color selector with defined color', () => {
   const {
     wrapper: { getByTestId },

--- a/src/components/ThemeEditor/components/ColorSelector/ColorSelector.test.tsx
+++ b/src/components/ThemeEditor/components/ColorSelector/ColorSelector.test.tsx
@@ -18,7 +18,23 @@ const render = (overProps: any = {}) => {
   };
 };
 
-HTMLCanvasElement.prototype.getContext = jest.fn();
+beforeEach(() => {
+  HTMLCanvasElement.prototype.getContext = jest.fn();
+  spyOn(Element.prototype, 'getBoundingClientRect').and.callFake(
+    jasmine
+      .createSpy('getBoundingClientRect')
+      .and.returnValue({
+        x: 1,
+        y: 1,
+        top: 1,
+        left: 1,
+        right: 1,
+        bottom: 1,
+        height: 100,
+        width: 100,
+      })
+  );
+});
 
 test('should render color selector with defined color', () => {
   const {

--- a/src/components/ThemeEditor/components/ColorSelector/ColorSelector.test.tsx
+++ b/src/components/ThemeEditor/components/ColorSelector/ColorSelector.test.tsx
@@ -20,20 +20,13 @@ const render = (overProps: any = {}) => {
 
 beforeEach(() => {
   HTMLCanvasElement.prototype.getContext = jest.fn();
-  spyOn(Element.prototype, 'getBoundingClientRect').and.callFake(
-    jasmine
-      .createSpy('getBoundingClientRect')
-      .and.returnValue({
-        x: 1,
-        y: 1,
-        top: 1,
-        left: 1,
-        right: 1,
-        bottom: 1,
-        height: 100,
-        width: 100,
-      })
-  );
+  Element.prototype.getBoundingClientRect = jest
+    .fn()
+    .mockImplementation(() => ({
+      x: 1,
+      y: 1,
+      height: 100,
+    }));
 });
 
 test('should render color selector with defined color', () => {

--- a/src/components/ThemeEditor/components/ColorSelector/ColorSelector.tsx
+++ b/src/components/ThemeEditor/components/ColorSelector/ColorSelector.tsx
@@ -43,6 +43,7 @@ const ColorSelector: FC<Props> = ({
 
   const setPickerPosition = () => {
     const dropdownRect = dropdownRef.current.getBoundingClientRect();
+    if (dropdownRect.y === undefined) return;
     setColorPickerPosition({
       x: dropdownRect.x,
       y: dropdownRect.y + window.scrollY + dropdownRect.height + modalScrollY,

--- a/src/components/ThemeEditor/components/ColorSelector/ColorSelector.tsx
+++ b/src/components/ThemeEditor/components/ColorSelector/ColorSelector.tsx
@@ -43,7 +43,6 @@ const ColorSelector: FC<Props> = ({
 
   const setPickerPosition = () => {
     const dropdownRect = dropdownRef.current.getBoundingClientRect();
-    if (dropdownRect.y === undefined) return;
     setColorPickerPosition({
       x: dropdownRect.x,
       y: dropdownRect.y + window.scrollY + dropdownRect.height + modalScrollY,


### PR DESCRIPTION
Fixed color selector test error, which was caused by missing _getContext_ of _HTMLCanvasElement_ and missing _getBoundingClientRect_ of ref element on initial render.