### PR TITLE
fix: 🐛 visualization widget clone

### DIFF
--- a/src/modules/widgets/__snapshots__/reducer.test.ts.snap
+++ b/src/modules/widgets/__snapshots__/reducer.test.ts.snap
@@ -49,6 +49,7 @@ Object {
   "isTitleCover": false,
   "widget": Object {
     "datePickerId": null,
+    "filterIds": Array [],
     "id": "@widget/id",
     "position": Object {
       "h": 2,
@@ -84,6 +85,7 @@ Object {
     "isTitleCover": false,
     "widget": Object {
       "datePickerId": null,
+      "filterIds": Array [],
       "id": "@widget/id",
       "position": Object {
         "h": 2,

--- a/src/modules/widgets/fixtures.ts
+++ b/src/modules/widgets/fixtures.ts
@@ -16,6 +16,7 @@ export const widget: WidgetItem = {
     position: { x: 3, y: 2, w: 6, h: 2 },
     query: null,
     datePickerId: null,
+    filterIds: [],
     settings: {
       chartSettings: {},
       visualizationType: null,

--- a/src/modules/widgets/widgetsSaga.ts
+++ b/src/modules/widgets/widgetsSaga.ts
@@ -339,6 +339,7 @@ export function* cloneWidget({
     widgetSettings = {
       ...widgetSettings,
       datePickerId: null,
+      filterIds: [],
     } as ChartWidget;
   }
 


### PR DESCRIPTION
This small pull request - fixes the issue related with using filter widget references during clone operation.